### PR TITLE
[Fix] InfoSection 컴포넌트에서 InfoSectionDot의 위치가 적용이 안되던 문제 해결 (CC-146)

### DIFF
--- a/Caecae/src/components/common/InfoSection/InfoSection.tsx
+++ b/Caecae/src/components/common/InfoSection/InfoSection.tsx
@@ -53,19 +53,19 @@ interface InfoSectionDotProps {
 }
 
 const InfoSectionDot = ({
-  top = 0,
-  bottom = 0,
-  left = 0,
-  right = 0,
+  top,
+  bottom,
+  left,
+  right,
 }: InfoSectionDotProps) => {
   const style: React.CSSProperties = {
-    top: `${top}px`,
-    bottom: `${bottom}px`,
-    left: `${left}px`,
-    right: `${right}px`,
     width: "20px",
     position: "absolute",
-    zIndex: "10",
+    zIndex: 10,
+    ...(top !== undefined && { top: `${top}px` }),
+    ...(bottom !== undefined && { bottom: `${bottom}px` }),
+    ...(left !== undefined && { left: `${left}px` }),
+    ...(right !== undefined && { right: `${right}px` }),
   };
 
   return (


### PR DESCRIPTION
## ✅ 구현사항
- InfoSection에 InfoSectionDot의 위치가 적용이 안되던 문제를 리팩토링을 통해 해결
<img width="1711" alt="스크린샷 2024-08-13 오후 12 20 57" src="https://github.com/user-attachments/assets/efb2c819-9dfe-4fa1-978a-2b10525773a3">

## InfoSection 리팩토링 코드 부분

```typescript
const InfoSectionDot = ({
  top,
  bottom,
  left,
  right,
}: InfoSectionDotProps) => {
  const style: React.CSSProperties = {
    width: "20px",
    position: "absolute",
    zIndex: 10,
    ...(top !== undefined && { top: `${top}px` }),
    ...(bottom !== undefined && { bottom: `${bottom}px` }),
    ...(left !== undefined && { left: `${left}px` }),
    ...(right !== undefined && { right: `${right}px` }),
  };
```
스프레드 연산자를 사용하여 지정된 top, bottom, left, right를 동적으로 적용