### PR TITLE
[Fix] 다른 페이지로 라우팅 되었을 때 스크롤바가 맨위로 안가는 버그 수정

### DIFF
--- a/Caecae/src/shared/Hyunouter/Router.tsx
+++ b/Caecae/src/shared/Hyunouter/Router.tsx
@@ -35,6 +35,7 @@ const Router: FC<RouterProps> = ({ children }) => {
         window.history.pushState({}, "", newPath);
       }
       setPath(newPath);
+      window.scrollTo(0, 0);
     }
   };
   const contextValue = {


### PR DESCRIPTION
## ✅구현사항
- 새로운 path로 이동했을 때 스크롤바가 맨위로 가도록 Router.tsx 로직 수정