### PR TITLE
[Hotfix] 레이싱 게임에서 점수 백분위 api 연결이 중복해서 여러번 호출되는 문제 해결

### DIFF
--- a/Caecae/src/hooks/index.tsx
+++ b/Caecae/src/hooks/index.tsx
@@ -2,10 +2,12 @@ import useChangeDependency from "./useChangeDependency";
 import useComponentPosition from "./useComponentRect";
 import useForceRendering from "./useForceRendering";
 import useSpecificTimeEffect from "./useSpecificTimeEffect";
+import useDebounce from "./useDebounce";
 
 export {
   useChangeDependency,
   useComponentPosition,
   useForceRendering,
   useSpecificTimeEffect,
+  useDebounce,
 };

--- a/Caecae/src/hooks/useDebounce.tsx
+++ b/Caecae/src/hooks/useDebounce.tsx
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;


### PR DESCRIPTION
## ✅ 구현사항
- useDebounce 커스텀 훅 구현
- 레이싱 게임 점수 백분위 api를 게임 종료 시 한 번만 호출하도록 구현